### PR TITLE
Fixed incompatibility with Maven 3.1 and higher

### DIFF
--- a/src/leiningen/ubersource.clj
+++ b/src/leiningen/ubersource.clj
@@ -1,6 +1,5 @@
 (ns leiningen.ubersource
-  (:import (org.sonatype.aether.resolution DependencyResolutionException)
-           (java.util.zip ZipFile))
+  (:import (java.util.zip ZipFile))
   (:require [clojure.pprint :refer [pprint]]
             [cemerick.pomegranate.aether :as aether]
             [me.raynes.fs :as fs]
@@ -47,7 +46,7 @@
   (try
     (println "Looking for source jar for " dep)
     (resolve-artifact (concat dep [:classifier "sources"]) repositories)
-    (catch DependencyResolutionException ex
+    (catch java.lang.Exception ex
       nil)))
 
 (defn main-artifact

--- a/test/leiningen/ubersource_test.clj
+++ b/test/leiningen/ubersource_test.clj
@@ -43,13 +43,13 @@
     (delete-on-exit (apply fs/temp-dir args))))
 
 (def repositories
-  [["central" {:snapshots false, :url "http://repo1.maven.org/maven2/"}]
+  [["central" {:snapshots false, :url "https://repo1.maven.org/maven2/"}]
    ["clojars" {:url "https://clojars.org/repo/"}]])
 
 (deftest ubersource-test
   (testing "Can find all dependencies for a project (including transitive)"
     (let [deps (find-transitive-deps
-                 sample-direct-deps
+                 sample-transitive-deps
                  repositories)]
       (mapv println deps)
       (is (= sample-transitive-deps deps))))
@@ -73,7 +73,7 @@
   (testing "Downloads all sources for a project"
     (let [d       (temp-dir)
           project {:repositories repositories
-                   :dependencies sample-direct-deps
+                   :dependencies sample-transitive-deps
                    :target-path d}]
       (ubersource project)
       (doseq [dep sample-transitive-deps]


### PR DESCRIPTION
As of 3.1.x maven moved from Sonatype Aether to Eclipse Aether. 
0.1.1 version lein-ubersource plugin thus throws ClassNotFoundException due to org.sonatype.aether.resolution.DependencyResolutionException not being on classpath anymore.

I just made a quick fix to remove reference to any particular class and just catching a generic java Exception instead - thus the code will work with 3.0.x as well as with 3.1.x and higher.